### PR TITLE
feat(DB): Add table creation in test environment

### DIFF
--- a/app/config/.env.example
+++ b/app/config/.env.example
@@ -1,3 +1,4 @@
-DB_URL=mysql+aiomysql://root:root@localhost:3306
+DB_URL=mysql+aiomysql://root:root@localhost:3306/pseudolab
 DISCORD_CLIENT_ID=DiscordClientID
 DISCORD_CLIENT_SECRET=DiscordClientSecret
+ENV=test

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -12,8 +12,9 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from dotenv import load_dotenv
+from models.base import Base
 
-load_dotenv("app/config/.env", override=True)
+load_dotenv("config/.env", override=True)
 
 
 class Database:
@@ -33,6 +34,12 @@ class Database:
             future=True,
         )
         self.async_scoped_session = async_scoped_session(self.async_session_factory, scopefunc=current_task)
+
+    async def create_database(self) -> None:
+        if os.getenv("ENV") == "test":
+            async with self.async_engine.begin() as conn:
+                await conn.run_sync(Base.metadata.drop_all)
+                await conn.run_sync(Base.metadata.create_all)
 
     async def get_session(self) -> AsyncIterator[AsyncSession]:
         async with self.async_scoped_session() as session:

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from api import routers
 async def lifespan(app: FastAPI):
     # 서버 시작 전 초기화 단계 작성
     db.initialize()
+    await db.create_database()
     yield
     # Clean up the ML models and release the resources
 


### PR DESCRIPTION
❗환경변수 `ENV` 를 추가하였습니다.

- `ENV` 값이 `test`일 경우 기존 테이블을 드랍하고 새로 생성하게 됩니다.

```python
if os.getenv("ENV") == "test":
    async with self.async_engine.begin() as conn:
        await conn.run_sync(Base.metadata.drop_all)
        await conn.run_sync(Base.metadata.create_all)
...

@asynccontextmanager
async def lifespan(app: FastAPI):
    # 서버 시작 전 초기화 단계 작성
    db.initialize()
    await db.create_database()
    yield
```

💊 개발시에 테이블을 생성하고 수정하는데 alembic으로 매번 테이블을 관리해주기가 번거로워서 작성해보았는데 의견부탁드립니다!! 