### PR TITLE
feat(bingo_event): bingo_count, event_users_count에 해당하는 빙고 이벤트 당첨 유저 목록을 반환하는 api 생성했습니다.

### DIFF
--- a/app/api/bingo/bingo_boards/routes.py
+++ b/app/api/bingo/bingo_boards/routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Path
 
-from .schema import BingoBoardRequest, BingoBoardResponse, UpdateBingoCountResponse, UserSelectedWordsResponse, UpdateBingoStatusResponse
+from .schema import BingoBoardRequest, BingoBoardResponse, UpdateBingoCountResponse, UserSelectedWordsResponse, UpdateBingoStatusResponse, GetUserBingoEventUser
 from .services import (
     CreateBingoBoard,
     GetBingoBoardByUserId,
@@ -8,6 +8,7 @@ from .services import (
     UpdateBingoCount,
     GetUserSelectedWords,
     UpdateBingoStatusBySelectedUser,
+    GetBingoEventUser,
 )
 
 
@@ -60,3 +61,11 @@ async def update_bingo_status(
     bingo_boards: UpdateBingoStatusBySelectedUser = Depends(UpdateBingoStatusBySelectedUser),
 ):
     return await bingo_boards.execute(send_user_id, receive_user_id)
+
+@bingo_boards_router.get("/bingo_event_users/{bingo_count}/{event_users_count}", response_model=GetUserBingoEventUser)
+async def get_bingo_event_users(
+    bingo_count: int = Path(..., title="이벤트 조건 빙고 갯수", ge=1),
+    event_users_count: int = Path(..., title="이벤트 당첨 유저 인원", ge=1),
+    bingo_boards: GetBingoEventUser = Depends(GetBingoEventUser),
+):
+    return await bingo_boards.execute(bingo_count, event_users_count)

--- a/app/api/bingo/bingo_boards/routes.py
+++ b/app/api/bingo/bingo_boards/routes.py
@@ -62,10 +62,9 @@ async def update_bingo_status(
 ):
     return await bingo_boards.execute(send_user_id, receive_user_id)
 
-@bingo_boards_router.get("/bingo_event_users/{bingo_count}/{event_users_count}", response_model=GetUserBingoEventUser)
+@bingo_boards_router.get("/bingo_event_users/{bingo_count}", response_model=GetUserBingoEventUser)
 async def get_bingo_event_users(
     bingo_count: int = Path(..., title="이벤트 조건 빙고 갯수", ge=1),
-    event_users_count: int = Path(..., title="이벤트 당첨 유저 인원", ge=1),
     bingo_boards: GetBingoEventUser = Depends(GetBingoEventUser),
 ):
-    return await bingo_boards.execute(bingo_count, event_users_count)
+    return await bingo_boards.execute(bingo_count)

--- a/app/api/bingo/bingo_boards/schema.py
+++ b/app/api/bingo/bingo_boards/schema.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pydantic import BaseModel, Field
 
 from core.base_schema import BaseSchema
+from models.bingo.schema import BingoEventUserInfo
 
 
 class BingoBoardRequest(BaseModel):
@@ -67,4 +68,5 @@ class UpdateBingoStatusResponse(BaseSchema):
     bingo_count: Optional[int] = Field(title="업데이트된 빙고 갯수", default=None)
 
 class GetUserBingoEventUser(BaseSchema):
-    bingo_event_users: Optional[list[str]] = Field(title="빙고 이벤트 당첨 유저 목록", default=None)
+    bingo_event_users: Optional[list[BingoEventUserInfo]] = Field(title="빙고 이벤트 당첨 유저 목록", default=None)
+

--- a/app/api/bingo/bingo_boards/schema.py
+++ b/app/api/bingo/bingo_boards/schema.py
@@ -65,3 +65,6 @@ class UpdateBingoStatusResponse(BaseSchema):
     receive_user_id: Optional[int] = Field(title="대상 유저 ID", default=None)
     updated_words: Optional[list[str]] = Field(title="업데이트된 단어들", default=None)
     bingo_count: Optional[int] = Field(title="업데이트된 빙고 갯수", default=None)
+
+class GetUserBingoEventUser(BaseSchema):
+    bingo_event_users: Optional[list[str]] = Field(title="빙고 이벤트 당첨 유저 목록", default=None)

--- a/app/api/bingo/bingo_boards/services.py
+++ b/app/api/bingo/bingo_boards/services.py
@@ -1,6 +1,6 @@
 from core.db import AsyncSessionDepends
 from models.bingo import BingoBoards
-from api.bingo.bingo_boards.schema import BingoBoardResponse, UpdateBingoCountResponse, UserSelectedWordsResponse, UpdateBingoStatusResponse
+from api.bingo.bingo_boards.schema import BingoBoardResponse, UpdateBingoCountResponse, UserSelectedWordsResponse, UpdateBingoStatusResponse, GetUserBingoEventUser
 
 
 class BaseBingoBoard:
@@ -59,3 +59,11 @@ class UpdateBingoStatusBySelectedUser(BaseBingoBoard):
             return UpdateBingoStatusResponse(**res.__dict__, ok=True, message="빙고판 상태 업데이트에 성공하였습니다.")
         except ValueError as e:
             return UpdateBingoStatusResponse(ok=False, message=str(e))
+
+class GetBingoEventUser(BaseBingoBoard):
+    async def execute(self, bingo_count: int, event_users_count: int) -> list[str]:
+        try:
+            res = await BingoBoards.get_bingo_event_users(self.async_session, bingo_count, event_users_count)
+            return GetUserBingoEventUser(bingo_event_users=res, ok=True, message="빙고 이벤트 당첨 유저 목록 생성에 성공하였습니다.")
+        except ValueError as e:
+            return GetUserBingoEventUser(ok=False, message=str(e))

--- a/app/api/bingo/bingo_boards/services.py
+++ b/app/api/bingo/bingo_boards/services.py
@@ -61,9 +61,9 @@ class UpdateBingoStatusBySelectedUser(BaseBingoBoard):
             return UpdateBingoStatusResponse(ok=False, message=str(e))
 
 class GetBingoEventUser(BaseBingoBoard):
-    async def execute(self, bingo_count: int, event_users_count: int) -> list[str]:
+    async def execute(self, bingo_count: int) -> list[str]:
         try:
-            res = await BingoBoards.get_bingo_event_users(self.async_session, bingo_count, event_users_count)
+            res = await BingoBoards.get_bingo_event_users(self.async_session, bingo_count)
             return GetUserBingoEventUser(bingo_event_users=res, ok=True, message="빙고 이벤트 당첨 유저 목록 생성에 성공하였습니다.")
         except ValueError as e:
             return GetUserBingoEventUser(ok=False, message=str(e))

--- a/app/models/bingo/bingo_boards.py
+++ b/app/models/bingo/bingo_boards.py
@@ -118,8 +118,8 @@ class BingoBoards(Base):
         )
     
     @classmethod
-    async def get_bingo_event_users(cls, session: AsyncSession, bingo_count: int, event_users_count: int) -> list:
         query = select(cls).filter(cls.bingo_count >= bingo_count)
+    async def get_bingo_event_users(cls, session: AsyncSession, bingo_count: int) -> list:
         result = await session.execute(query)
         bingo_event_users = [board.user_id for board in result.scalars().all()]
         

--- a/app/models/bingo/schema.py
+++ b/app/models/bingo/schema.py
@@ -24,3 +24,8 @@ class BingoInteractionSchema(BaseModel):
     receive_user_id: int
     updated_words: list[str]
     bingo_count: int
+
+class BingoEventUserInfo(BaseModel):
+    rank: int
+    user_name: str
+    bingo_count: int

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -35,6 +35,14 @@ class BingoUser(Base):
         if not user:
             raise ValueError(f"{username} 의 빙고 유저가 존재하지 않습니다.")
         return user
+    
+    @classmethod
+    async def get_user_by_id(cls, session: AsyncSession, user_id: int):
+        res = await session.execute(select(cls).where(cls.user_id == user_id))
+        user = res.scalars().first()
+        if not user:
+            raise ValueError(f"{user_id} 의 빙고 유저가 존재하지 않습니다.")
+        return user
 
 
 class User(Base):


### PR DESCRIPTION
1. bingo_count에 이상의 빙고가 있는 유저를 리스트로 생성하였습니다.
2. 해당 리스트에서 event_users_count에 해당하는 인원만큼 랜덤하게 추출합니다.
3. 최종적으로 랜덤하게 선택된 유저들의 username을 반환합니다.

- bingo_count 이상의 빙고를 달성한 유저보다 event_users_count가 클 경우 에러 메시지를 반환합니다.

고려사항
- 현재는 당첨 인원을 리스트로 한번에 반환하다보니 인원이 맞지 않을경우 바로 에러메시지를 반환합니다. 
-> 이 부분을 인원이 부족하더라도 bingo_count 달성한 유저가 있다면 반환을 하게 변경해야할까요?
다만 그럴 경우, 
1. 당첨 유저를 제외하고 bingo_count, event_users_count 를 조절하여 새롭게 이벤트 당첨 유저를 뽑기
2. 새로 뽑지 않고 일부 당첨된 유저들로 끝내기
3. 아예 bingo_count 기준을 낮춰서 더 많은 달성인원이 한번의 랜덤뽑기로 당첨되도록 재조정하기

와 같이 상황을 고려해야할 것 같습니다!